### PR TITLE
Include the css relatively

### DIFF
--- a/src/components/VueJkanban.vue
+++ b/src/components/VueJkanban.vue
@@ -4,6 +4,7 @@
 
 <script>
 require("jkanban")
+require("jkanban/jkanban.css")
 
 export default {
   name: 'vue-jkanban',
@@ -106,5 +107,4 @@ export default {
 </script>
 
 <style>
- @import '../../node_modules/jkanban/jkanban.css';
 </style>


### PR DESCRIPTION
By including the css in this way it is also available when installing VueJkanban via npm and using it in another application.